### PR TITLE
[FE] NullPointerException on lambdef

### DIFF
--- a/pylisa/src/main/java/it/unive/pylisa/PyFrontend.java
+++ b/pylisa/src/main/java/it/unive/pylisa/PyFrontend.java
@@ -1315,7 +1315,12 @@ public class PyFrontend extends Python3ParserBaseVisitor<Object> {
 	@Override
 	public Expression visitLambdef(
 			LambdefContext ctx) {
-		List<Expression> args = extractNamesFromVarArgList(ctx.varargslist());
+		List<Expression> args;
+		if (ctx.varargslist() != null) 
+			args = extractNamesFromVarArgList(ctx.varargslist());
+		else
+			args = new ArrayList<Expression>();
+
 		Expression body = visitTest(ctx.test());
 		return new LambdaExpression(
 				args,
@@ -1327,7 +1332,12 @@ public class PyFrontend extends Python3ParserBaseVisitor<Object> {
 	@Override
 	public Expression visitLambdef_nocond(
 			Lambdef_nocondContext ctx) {
-		List<Expression> args = extractNamesFromVarArgList(ctx.varargslist());
+		List<Expression> args;
+		if (ctx.varargslist() != null) 
+			args = extractNamesFromVarArgList(ctx.varargslist());
+		else
+			args = new ArrayList<Expression>();
+
 		Expression body = visitTest_nocond(ctx.test_nocond());
 		return new LambdaExpression(
 				args,


### PR DESCRIPTION
In **LambdefContext** and **Lambdef_nocondContext**, the **varargslist()** method can return null:

```
lambdef
   : 'lambda' (varargslist)? ':' test
   ;

lambdef_nocond
   : 'lambda' (varargslist)? ':' test_nocond
   ;
```

In **visitLambdef** and **visitLambdef_nocond** methods we access varargslist() without checking its nullity. This will throw a NullPointerException on **extractNamesFromVarArgList** method during the analysis of lambda functions without arguments, such as **lambda: None**.

This PR will fix this.

Closes #14